### PR TITLE
Cleaner CSS color scheme

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -1,6 +1,4 @@
 body {
-	background: #151515 ;
-	color: white ;
 	max-width: 800px ;
 	margin: auto ;
 	padding: 0 16px ;
@@ -8,20 +6,8 @@ body {
 	font-family: sans-serif ;
 }
 
-a {
-	color: lightblue ;
-}
-
-a:visited {
-	color: gray ;
-}
-
 h1 {
 	text-align: center ;
-}
-
-h2 {
-	color: tomato ;
 }
 
 footer {
@@ -37,7 +23,7 @@ img {
 
 code {
 	overflow-wrap: break-word ;
-	color: lime ;
+	color: forestgreen ;
 }
 
 img[alt="BTC logo"],
@@ -47,22 +33,22 @@ img[alt="XMR Logo"] {
 	display: inline ;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
 	body {
-		background: white ;
-		color: black ;
+		background: #151515 ;
+		color: white ;
 	}
 	a {
-		color: blue ;
+		color: lightblue ;
 	}
 	a:visited {
-		color: purple ;
+		color: gray ;
 	}
 	h2 {
-		color: inherit ;
+		color: tomato ;
 	}
 	code {
-		color: forestgreen ;
+		color: lime ;
 	}
 }
 


### PR DESCRIPTION
Since the default stylesheet of the main browsers it's mainly light theme it's easier and less bloated to just make a query for the dark scheme

<!--
- Recipes should be `.md` files in the `src/` directory.  Look at already
  existing `.md` files for examples or see [example](example.md).
- File names should be the name of the dish with words separated by hyphens
  (`-`). Not underscores, and definitely not spaces.
- Recipe must be based, i.e. good traditional and substantial food. Nothing
  ironic, meme-tier hyper-sugary, meat-substitute, etc.
- Be sure to add a small number of relevant  tags to your recipe (and remove
  the dummy tags). Try to use already existing tags.
- Don't include salt and pepper and other ubiquitous things in the ingredients
  list.
-->
